### PR TITLE
Accept Trailing Slashes and base paths in nested configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ const {path, value} = switchPath('/home/foo', {
 // value is 456
 ```
 
+Supports trailing slashes
+
+```js
+const {path, value} = switchPath('/home/foo/', {
+  '/bar': 123,
+  '/home/foo': 456,
+});
+// path is `/home/foo`
+// value is 456
+```
+
 Supports nested route configuration:
 
 ```js
@@ -29,6 +40,18 @@ const {path, value} = switchPath('/home/foo', {
   },
 });
 // path is `/home/foo`
+// value is 456
+```
+Supports base paths in nested route configurations
+```js
+const {path, value} = switchPath('/home', {
+  '/bar': 123,
+  '/home': {
+    '/': 456,
+    '/foo': 789
+  }
+});
+// path is `/home`
 // value is 456
 ```
 
@@ -64,5 +87,19 @@ const {path, value} = switchPath('/home/1736', {
   },
 });
 // path is `/home/1736`
+// value is 'id is 1736'
+```
+
+Match a route with `:param` parameters base inside nested configurations:
+
+```js
+const {path, value} = switchPath('/1736', {
+  '/bar': 123,
+  '/:id': {
+    '/': id => `id is ${id}`,
+    '/home': 789
+  }
+});
+// path is `/1736`
 // value is 'id is 1736'
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,11 @@ function switchPath(sourcePath, routes) {
       return {path: pattern, value: routes[pattern]}
     }
   }
+
+  if (matchedPath !== sourcePath) {
+    return {path: null, value: null}
+  }
+
   return {path: matchedPath, value}
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,13 +60,6 @@ function getParamsFnValue(paramFn, params) {
   return handleTrailingSlash(paramFn)(params)
 }
 
-function validateMatchedPath(matchedPath, sourcePath, value) {
-  if (matchedPath !== sourcePath && matchedPath !== sourcePath.slice(0, -1)) {
-    return {path: null, value: null}
-  }
-  return {path: matchedPath, value}
-}
-
 function switchPath(sourcePath, routes) {
   validateSwitchPathPreconditions(sourcePath, routes)
   let matchedPath = null
@@ -97,7 +90,7 @@ function switchPath(sourcePath, routes) {
     }
   }
 
-  return validateMatchedPath(matchedPath, sourcePath, value)
+  return {path: matchedPath, value}
 }
 
 module.exports = switchPath

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,13 @@ function validatePatternPreconditions(pattern) {
   }
 }
 
+function validateMatchedPath(matchedPath, sourcePath, value) {
+  if (matchedPath !== sourcePath) {
+    return {path: null, value: null}
+  }
+  return {path: matchedPath, value}
+}
+
 function switchPath(sourcePath, routes) {
   validateSwitchPathPreconditions(sourcePath, routes)
   let matchedPath = null
@@ -80,11 +87,7 @@ function switchPath(sourcePath, routes) {
     }
   }
 
-  if (matchedPath !== sourcePath) {
-    return {path: null, value: null}
-  }
-
-  return {path: matchedPath, value}
+  return validateMatchedPath(matchedPath, sourcePath, value)
 }
 
 module.exports = switchPath

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,18 @@ describe('switchPath', () => {
     expect(value).to.be.equal(456);
   });
 
+  it('should match a base path in a nested configuration', () => {
+    const {path, value} = switchPath('/home', {
+      '/bar': 123,
+      '/home': {
+        '/': 456,
+        '/foo': 789
+      }
+    });
+    expect(path).to.be.equal('/home');
+    expect(value).to.be.equal(456);
+  });
+
   it('should match a basic path in a nested configuration', () => {
     const {path, value} = switchPath('/home/foo', {
       '/bar': 123,
@@ -19,6 +31,7 @@ describe('switchPath', () => {
         '/foo': 456,
       },
     });
+
     expect(path).to.be.equal('/home/foo');
     expect(value).to.be.equal(456);
   });
@@ -30,6 +43,17 @@ describe('switchPath', () => {
     });
     expect(path).to.be.equal(null);
     expect(value).to.be.equal(null);
+  });
+
+  it('should match a path with an extra trailing slash', () => {
+    const {path, value} = switchPath('/home/foo/', {
+      '/bar': 123,
+      '/home': {
+        '/foo': 456
+      }
+    });
+    expect(path).to.be.equal('/home/foo');
+    expect(value).to.be.equal(456);
   });
 
   it('should match a path with a parameter', () => {
@@ -51,4 +75,16 @@ describe('switchPath', () => {
     expect(path).to.be.equal('/home/1736');
     expect(value).to.be.equal('id is 1736');
   });
+
+  it('should match the base of a path with a parameter in a nested configuration', () => {
+    const {path, value} = switchPath('/1736', {
+      '/bar': 123,
+      '/:id': {
+        '/': id => `id is ${id}`,
+        '/home': 789
+      }
+    });
+    expect(path).to.be.equal('/1736');
+    expect(value).to.be.equal('id is 1736');
+  })
 });

--- a/test/index.js
+++ b/test/index.js
@@ -36,13 +36,13 @@ describe('switchPath', () => {
     expect(value).to.be.equal(456);
   });
 
-  it('should NOT match a path on an incomplete pattern', () => {
+  it('should match a path on an incomplete pattern', () => {
     const {path, value} = switchPath('/home/foo', {
       '/bar': 123,
       '/home': 456,
     });
-    expect(path).to.be.equal(null);
-    expect(value).to.be.equal(null);
+    expect(path).to.be.equal('/home');
+    expect(value).to.be.equal(456);
   });
 
   it('should match a path with an extra trailing slash', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -23,13 +23,13 @@ describe('switchPath', () => {
     expect(value).to.be.equal(456);
   });
 
-  it('should match a path on an incomplete pattern', () => {
+  it('should NOT match a path on an incomplete pattern', () => {
     const {path, value} = switchPath('/home/foo', {
       '/bar': 123,
       '/home': 456,
     });
-    expect(path).to.be.equal('/home');
-    expect(value).to.be.equal(456);
+    expect(path).to.be.equal(null);
+    expect(value).to.be.equal(null);
   });
 
   it('should match a path with a parameter', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -86,5 +86,5 @@ describe('switchPath', () => {
     });
     expect(path).to.be.equal('/1736');
     expect(value).to.be.equal('id is 1736');
-  })
+  });
 });


### PR DESCRIPTION
I'm not sure if this is how you would like to handle this, but it's a simple solution but it also removes 'optimistic matching'. Which I have preference for, but you may not see desire for that.
