### PR TITLE
Fix partial matching :param type routes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,19 @@ function splitPath(path) {
   return pathParts
 }
 
+function matchPartial(sourcePath, pattern) {
+  const patternParts = splitPath(pattern)
+  const sourceParts = splitPath(sourcePath)
+
+  const matchedParts = []
+
+  for (let i = 0; i < patternParts.length; ++i) {
+    matchedParts.push(sourceParts[i])
+  }
+
+  return matchedParts.join(`/`)
+}
+
 function validatePath(sourcePath, matchedPath) {
   if (matchedPath === null) {
     return ``
@@ -136,7 +149,7 @@ function switchPath(sourcePath, routes) {
     }
     const params = matchesWithParams(sourcePath, pattern)
     if (params.length > 0 && betterMatch(sourcePath, matchedPath)) {
-      matchedPath = sourcePath
+      matchedPath = matchPartial(sourcePath, pattern)
       value = getParamsFnValue(routes[pattern], params)
     }
     if (isRouteConfigurationObject(routes[pattern]) && params.length === 0) {

--- a/test/index.js
+++ b/test/index.js
@@ -193,4 +193,24 @@ describe('switchPath corner cases', () => {
     expect(path).to.be.equal('/home/123');
     expect(value).to.be.equal('home is 123');
   });
+
+  it('should partially match :key type params', () => {
+    const {path, value} = switchPath('/home/123/456', {
+      '/': 'root',
+      '/home/:id': id => `home is ${id}`,
+      '/external/:id': id => `external is ${id}`,
+    });
+    expect(path).to.be.equal('/home/123');
+    expect(value).to.be.equal('home is 123');
+  });
+
+  it('should partially match multiple :key type params', () => {
+    const {path, value} = switchPath('/home/123/456/something', {
+      '/': 'root',
+      '/home/:id/:other': (id, other) => `${id}:${other}`,
+      '/external/:id/:other': (id, other) => `external`,
+    });
+    expect(path).to.be.equal('/home/123/456')
+    expect(value).to.be.equal('123:456')
+  })
 });


### PR DESCRIPTION
Add tests for partial matching `:param` type route patterns.
Add quick fix for partial matching of routes with `:param` type route patterns.
