### PR TITLE
Fix param bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ function switchPath(sourcePath, routes) {
       matchedValue = routes[pattern]
     }
 
-    const params = matchesWithParams(sourcePath, pattern)
+    const params = matchesWithParams(sourcePath, pattern).filter(Boolean)
 
     if (params.length > 0 && betterMatch(sourcePath, matchedPath)) {
       matchedPath = extractPartial(sourcePath, pattern)

--- a/test/index.js
+++ b/test/index.js
@@ -213,4 +213,14 @@ describe('switchPath corner cases', () => {
     expect(path).to.be.equal('/home/123/456')
     expect(value).to.be.equal('123:456')
   })
+
+  it('should not match a :key type route if no params are given', () => {
+    const {path, value} = switchPath('/', {
+      '/': 'root',
+      '/:id': (id) => `$id`
+    })
+
+    expect(path).to.be.equal('/')
+    expect(value).to.be.equal('root')
+  })
 });


### PR DESCRIPTION
Fixes a bug when there is a `:key` type param defined off an existing route, and a `:key` type param is _not_ what you want to match. e.g.

``` js
const {path, value} = switchPath('/', {
  '/': 'root',
  '/:key': key => '' + key,
})

console.log(path) // null
```

This is caused by the params evaluating to `[undefined]` which just doesn't work :smile:    
