### PR TITLE
Child path not validated.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,8 @@ function switchPath(sourcePath, routes) {
           routes[pattern]
         )
         const nestedPath = pattern + child.path
-        if (!child.path !== null &&
+        if (child.path !== null &&
+          validatePath(nestedPath, matchedPath) &&
           betterMatch(nestedPath, matchedPath))
         {
           matchedPath = nestedPath

--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,28 @@ function switchPathInputGuard(path, routes) {
   }
 }
 
+function validatePath(sourcePath, matchedPath) {
+  const sourceParts = splitPath(sourcePath)
+  const matchedParts = splitPath(matchedPath)
+
+  for (let i = 0; i < matchedParts.length; ++i) {
+    if (matchedParts[i] !== sourceParts[i]) {
+      return null
+    }
+  }
+
+  return `/${extractPartial(sourcePath, matchedPath)}`
+}
+
 function betterMatch(candidate, reference) {
   if (!isNotNull(candidate)) {
     return false
   }
   if (!isNotNull(reference)) {
     return true
+  }
+  if (!validatePath(candidate, reference)) {
+    return false
   }
   return candidate.length >= reference.length
 }
@@ -46,19 +62,6 @@ function matchesWithParams(sourcePath, pattern) {
 function getParamFnValue(paramFn, params) {
   const _paramFn = isRouteDefinition(paramFn) ? paramFn[`/`] : paramFn
   return typeof _paramFn === `function` ? _paramFn(...params) : _paramFn
-}
-
-function validatePath(sourcePath, matchedPath) {
-  const sourceParts = splitPath(sourcePath)
-  const matchedParts = splitPath(matchedPath)
-
-  for (let i = 0; i < matchedParts.length; ++i) {
-    if (matchedParts[i] !== sourceParts[i]) {
-      return null
-    }
-  }
-
-  return `/${extractPartial(sourcePath, matchedPath)}`
 }
 
 function validate({sourcePath, matchedPath, matchedValue, routes}) {
@@ -97,7 +100,6 @@ function switchPath(sourcePath, routes) {
         )
         const nestedPath = pattern + child.path
         if (child.path !== null &&
-          validatePath(nestedPath, matchedPath) &&
           betterMatch(nestedPath, matchedPath))
         {
           matchedPath = nestedPath

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,18 @@ describe('switchPath basic usage', () => {
     expect(value).to.be.equal(78);
   });
 
+  it('should match a base path having a match in a sibling\'s nested configuration', () => {
+    const {path, value} = switchPath('/bar', {
+      '/bar': 123,
+      '/home': {
+        '/': 456,
+        '/foo': 789
+      }
+    });
+    expect(path).to.be.equal('/bar');
+    expect(value).to.be.equal(123);
+  });
+
   it('should match a base path in a nested configuration', () => {
     const {path, value} = switchPath('/home', {
       '/bar': 123,


### PR DESCRIPTION
When comparing child paths, the procedure was not comparing the root path of the nested configuration and matching sub paths even though root path did not match. To fix, include path validation.

Also, `!child.path !== null` will always result in TRUE since `!` has precedence over `!==`. I assume intent is `child.path !== null`, and tests still pass.

See issue: https://github.com/staltz/switch-path/issues/19
