### PR TITLE
Fix for non-nested configuration & not found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function betterMatch(candidate, reference) {
   if (!validatePath(candidate, reference)) {
     return false
   }
-  return candidate.length >= reference.length
+  return candidate.length > reference.length
 }
 
 function matchesWithParams(sourcePath, pattern) {
@@ -67,9 +67,12 @@ function getParamFnValue(paramFn, params) {
 function validate({sourcePath, matchedPath, matchedValue, routes}) {
   let path = matchedPath ? validatePath(sourcePath, matchedPath) : null
   let value = matchedValue
-  if (!path || routes[`*`]) {
+  if (!path) {
     path = routes[`*`] ? sourcePath : null
     value = path ? routes[`*`] : null
+  } else if (routes[`*`] && betterMatch(sourcePath, path)) {
+    path = sourcePath
+    value = routes[`*`]
   }
   return {path, value}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ function getParamFnValue(paramFn, params) {
 function validate({sourcePath, matchedPath, matchedValue, routes}) {
   let path = matchedPath ? validatePath(sourcePath, matchedPath) : null
   let value = matchedValue
-  if (!path) {
+  if (!path || routes[`*`]) {
     path = routes[`*`] ? sourcePath : null
     value = path ? routes[`*`] : null
   }

--- a/test/index.js
+++ b/test/index.js
@@ -135,6 +135,18 @@ describe('switchPath basic usage', () => {
     expect(value).to.be.equal('Route not defined');
   });
 
+  it('should return match to a notFound pattern if provided non-nested configuration', () => {
+    const {path, value} = switchPath('/home/33/books/10', {
+      '/': 123,
+      '/authors': 234,
+      '/books': 345,
+      '/books/:id': 456,
+      '*': 'Route not defined'
+    });
+    expect(path).to.be.equal('/home/33/books/10');
+    expect(value).to.be.equal('Route not defined');
+  });
+
   it('should not prematurely match a notFound pattern', () => {
     const {path, value} = switchPath('/home/foo', {
       '*': 0,

--- a/test/index.js
+++ b/test/index.js
@@ -147,6 +147,76 @@ describe('switchPath basic usage', () => {
     expect(value).to.be.equal('Route not defined');
   });
 
+  it('should match a base root path when notFound is specified', () => {
+    const {path, value} = switchPath('/', {
+      '/': 123,
+      '*': 'Route not defined'
+    });
+    expect(path).to.be.equal('/');
+    expect(value).to.be.equal(123);
+  });
+
+  it('should match a base path when notFound is specified', () => {
+    const {path, value} = switchPath('/books', {
+      '/': 123,
+      '/books': 234,
+      '/books/:id': 345,
+      '*': 'Route not defined'
+    });
+    expect(path).to.be.equal('/books');
+    expect(value).to.be.equal(234);
+  });
+
+  it('should match a base parameter path when notFound is specified', () => {
+    const {path, value} = switchPath('/10', {
+      '/': 123,
+      '/:id': id => `id is ${id}`,
+      '*': 'Route not defined'
+    });
+    expect(path).to.be.equal('/10');
+    expect(value).to.be.equal('id is 10');
+  });
+
+  it('should match a base nested paramter path when notFound is specified', () => {
+    const {path, value} = switchPath('/1736', {
+      '/': 123,
+      '/bar': 234,
+      '/:id': {
+        '/': id => `id is ${id}`,
+        '/home': 345
+      },
+      '*': 'Route not defined'
+    });
+    expect(path).to.be.equal('/1736');
+    expect(value).to.be.equal('id is 1736');
+  });
+
+  it('should match a nested root path when notFound is specified', () => {
+    const {path, value} = switchPath('/books', {
+      '/': 123,
+      '/books': {
+        '/': 234,
+        '/:id': 345
+      },
+      '*': 'Route not defined'
+    });
+    expect(path).to.be.equal('/books');
+    expect(value).to.be.equal(234);
+  });
+
+  it('should match a nested parameter path when notFound is specified', () => {
+    const {path, value} = switchPath('/books/10', {
+      '/': 123,
+      '/books': {
+        '/': 234,
+        '/:id': id => `id is ${id}`
+      },
+      '*': 'Route not defined'
+    });
+    expect(path).to.be.equal('/books/10');
+    expect(value).to.be.equal('id is 10');
+  });
+
   it('should not prematurely match a notFound pattern', () => {
     const {path, value} = switchPath('/home/foo', {
       '*': 0,


### PR DESCRIPTION
This is a very simple fix for #16.  Took me a bit to understand the code via the debugger, but this passes all the tests, including the failing test case I added.

For reference, this was the existing test case (passing):

```js
it('should return match to a notFound pattern if provided', () => {
  const {path, value} = switchPath('/home/33/books/10', {
    '/': 123,
    '/authors': 234,
    '/books': {
      '/': 345,
      '/:id': 456
    },
    '*': 'Route not defined'
  });
  expect(path).to.be.equal('/home/33/books/10');
  expect(value).to.be.equal('Route not defined');
});
```

And the failing one I added, which is identical, but non-nested:

```js
it('should return match to a notFound pattern if provided non-nested configuration', () => {
  const {path, value} = switchPath('/home/33/books/10', {
    '/': 123,
    '/authors': 234,
    '/books': 345,
    '/books/:id': 456,
    '*': 'Route not defined'
  });
  expect(path).to.be.equal('/home/33/books/10');
  expect(value).to.be.equal('Route not defined');
});
```

Feel free to close if you don't think this is a robust enough solution to the problem.  Also, ping @TylorS and @Cmdv because they were working on this before in #17 and #18.