### PR TITLE
test(): add failing test for non-deterministic matching

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -276,4 +276,24 @@ describe('switchPath corner cases', () => {
     expect(path).to.be.equal('/')
     expect(value).to.be.equal('root')
   })
+
+  it('should deterministically match more specific path in case many match', () => {
+    (() => {
+      let {path, value} = switchPath('/home/specific', {
+        '/home/specific': 123,
+        '/home/:id': id => `id is ${id}`
+      });
+      expect(path).to.be.equal('/home/specific');
+      expect(value).to.be.equal(123);
+    })();
+
+    (() => {
+      let {path, value} = switchPath('/home/specific', {
+        '/home/:id': id => `id is ${id}`,
+        '/home/specific': 123
+      });
+      expect(path).to.be.equal('/home/specific');
+      expect(value).to.be.equal(123);
+    })();
+  });
 });


### PR DESCRIPTION
Ran into this problem this morning, where a `:param` path can out-compete a more specific path depending on the order of iteration over object keys.  I think this is due to the current behavior of [`betterMatch()`](https://github.com/staltz/switch-path/blob/be18c3d43605f6aefb048e3ee18ac7bbefe5bf0b/src/index.js#L35), which returns `true` if the `candidate.length` is greater OR EQUAL TO the `reference.length`.

Fortunately, this test passes against the implementation in my #24 pull request!  So if that PR is accepted, then this test can be safely merged.  If that PR is not accepted, then this report can help with any refactoring efforts.